### PR TITLE
Add missing InternalsVisibleTo attributes for DSC scenario

### DIFF
--- a/src/Microsoft.Management.Infrastructure/AssemblyInfo.cs
+++ b/src/Microsoft.Management.Infrastructure/AssemblyInfo.cs
@@ -8,6 +8,8 @@ using System.Runtime.InteropServices;
 [assembly:InternalsVisibleTo("Microsoft.Management.Infrastructure.Tests")]
 [assembly:AssemblyFileVersionAttribute("1.0.0.0")]
 [assembly:AssemblyVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("Microsoft.Windows.DSC.CoreConfProviders")]
+[assembly: InternalsVisibleTo("Microsoft.Management.Infrastructure.CimCmdlets")]
 #else
 [assembly: NeutralResourcesLanguage("en")]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
Adding InternalsVisibleTo attribute for Microsoft.Windows.DSC.CoreConfProviders and Microsoft.Management.Infrastructure.CimCmdlets to _CORECLR builds. There are more attributes not being included in _CORECLR but we have not identified if they will be necessary going forward
