### PR TITLE
Remove hardcoded .so from MI_PlatformSpecific.cs

### DIFF
--- a/src/Microsoft.Management.Infrastructure/Native/MI_PlatformSpecific.cs
+++ b/src/Microsoft.Management.Infrastructure/Native/MI_PlatformSpecific.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Management.Infrastructure.Native
         internal const CharSet AppropriateCharSet = CharSet.Ansi;
         internal const CallingConvention MiMainCallConvention = CallingConvention.Cdecl;
         internal const CallingConvention MiCallConvention = CallingConvention.Cdecl;
-        internal const string MI = "libmi.so";
-        internal const string MOFCodecHost = "libmi.so";
+        internal const string MI = "libmi";
+        internal const string MOFCodecHost = "libmi";
 
         internal static string PtrToString(IntPtr ptr)
         {


### PR DESCRIPTION
Fixes #33 

Remove hardcoded .so from the MI_PlatformSpecific.cs to fix loading on MacOS.